### PR TITLE
fixed python2 compatability in setup.py. tested in python2.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 import warnings
 from collections import namedtuple
+import io
 
 from moe import __version__
 
@@ -22,7 +23,7 @@ except ImportError:
 
 
 here = os.path.abspath(os.path.dirname(__file__))
-README = open(os.path.join(here, 'README.md'), encoding="latin-1").read()
+README = io.open(os.path.join(here, 'README.md'), encoding="latin-1").read()
 
 
 VERSION = __version__


### PR DESCRIPTION
I was receiving the following error when attempting to install in python 2.7:
```
        README = open(os.path.join(here, 'README.md'), encoding="latin-1").read()
TypeError: 'encoding' is an invalid keyword argument for this function
```
This is a compatability issue between Python2 and Python3. It seems that the python2 version of open does not accept the `encoding` argument, but the `io.open` function works in both python2 and python3.
